### PR TITLE
fix code blocks in markdown

### DIFF
--- a/source/cis-192/debugging_and_advanced_ssh.md
+++ b/source/cis-192/debugging_and_advanced_ssh.md
@@ -32,8 +32,6 @@ There are two things a good admin does well: Move from host to host and find pro
 SSH can use cryptographic keys to verify your identity. Run the following command on Opus to generate a key pair:
 
 ```
-
-```
 $ ssh-keygen -t rsa -b 4096
 Generating public/private rsa key pair.
 Enter file in which to save the key (/home/robot/.ssh/id_rsa): 

--- a/source/cis-192/dhcp_howto.md
+++ b/source/cis-192/dhcp_howto.md
@@ -53,11 +53,8 @@ max-lease-time 1200;
 Notice that you have setup your router's IP address at the DNS server. Since your hosts don't yet have IPv4 connectivity they can't use Cabrillo's IPv4 nameservers anyway. Soon your router will run DNS and this will work. These global options are sufficient for your network. A complicated network will have multiple scopes. Yours only has one so there's no real difference between global and local options. Add the following zone to your configuration file:
 
 ```
-subnet 10.192.0.0 netmask 255.255.0.0 { 
-  
-```
-
-option routers 10.192.0.1; 
+subnet 10.192.0.0 netmask 255.255.0.0 {
+  option routers 10.192.0.1; 
   option broadcast-address 10.192.255.255; 
   range 10.192.5.1 10.192.5.100;
 }

--- a/source/cis-192/dns.md
+++ b/source/cis-192/dns.md
@@ -58,8 +58,6 @@ Some examples:
 There are other useful things that dig can do easily. If you want to lookup the name for an IP address you can use the -x option:
 
 ```
-
-```
 dig -x 216.58.216.132
 dig -x 2607:f8b0:400a:806::2004
 ```
@@ -256,7 +254,6 @@ server3.matera.com IN A 1.2.3.6 # Oops! This means "server3.matera.com.matera.co
 
 In order for DNS to work you must let packets headed for UDP/53 through the firewall. Be sure that both IPv6 and IPv4 firewalls have rules. The examples below are how to add rules to your firewall.
 
-```
 
 ```
 # Allow UDP datagrams on port 53

--- a/source/cis-192/email_how_to.md
+++ b/source/cis-192/email_how_to.md
@@ -41,8 +41,6 @@ infra-server$ sudo apt-get install postfix
 After that you can have Ubuntu set it up with working defaults for you:
 
 ```
-
-```
 infra-server$
 dpkg-reconfigure postfix
 ```

--- a/source/cis-192/ipchains_howto.md
+++ b/source/cis-192/ipchains_howto.md
@@ -44,8 +44,6 @@ At this point in the class your IPv6 network is fully functional because there a
 By default Linux doesn't forward packets. You should have already turned on forwarding for IPv6. Before you begin working on your firewall you should double check that you have enabled forwarding for IPv4. To turn on forwarding you use the sysctl command. To turn on forwarding of IPv4 packets:
 
 ```
-
-```
 router$ sudo sysctl -w net.ipv4.ip_forward=1
 ```
 
@@ -160,8 +158,6 @@ router$ sudo ip6tables -A FORWARD -j LOG
 Finally verify that your firewall rules are complete:
 
 ```
-
-```
 router$ sudo iptables -L -n -v
 Chain INPUT (policy DROP 0 packets, 0 bytes)
 pkts bytes target   prot opt in   out   source        destination    
@@ -190,8 +186,6 @@ router$ sudo iptables -P FORWARD DROP
 ```
 
 Don't forget IPv6. Verify that your IPv6 firewall is complete:
-
-```
 
 ```
 router$ ip6tables -L -n -v

--- a/source/cis-192/project_debugging.md
+++ b/source/cis-192/project_debugging.md
@@ -347,9 +347,14 @@ User student
 ```
 
 From Tux ssh into each of your hosts and run a simple command like this:
-$ ssh router uname -aLinux router 4.4.0-66-generic #87-Ubuntu SMP Fri Mar 3 15:29:05 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
+```
+$ ssh router uname -a
+Linux router 4.4.0-66-generic #87-Ubuntu SMP Fri Mar 3 15:29:05 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
+```
 If you are not able to connect to your router or your hosts using SSH it's very likely at this point to be a firewall issue. If you can's SSH into your router check the INPUT chain on the router. If you can't SSH into your switch or servers check that the FORWARD chain in the IPv6 firewall allows NEW traffic on port 22. If you're like me, you hate to wast time. You can make it possible to login from Tux without a password by running the command:
+```
 $ ssh-copy-id <host>
+```
 That's it for now. There will be another debugging session on the last day of class.
 
 ## Still Have Problems? 

--- a/source/cis-192/project_debugging.md
+++ b/source/cis-192/project_debugging.md
@@ -10,7 +10,7 @@ Take a week to verify that your project is fully operational. After this week th
 
 ### 1. Reboot Every VM 
 
-Before you begin this checkup make sure that every VM has all configuration stored on disk. When I grade you, I'll ask to see the output of 'uptime' so that I know your VMs have recently rebooted. You can reboot them in any order. If all is well they will eventually come back online. \
+Before you begin this checkup make sure that every VM has all configuration stored on disk. When I grade you, I'll ask to see the output of 'uptime' so that I know your VMs have recently rebooted. You can reboot them in any order. If all is well they will eventually come back online.
 
 ### 2. Check Host Names 
 

--- a/source/cis-192/project_debugging.md
+++ b/source/cis-192/project_debugging.md
@@ -17,15 +17,11 @@ Before you begin this checkup make sure that every VM has all configuration stor
 Each of your machines should have an assigned hostname. Verify that you have set your new hostname in two places: /etc/hostname and /etc/hosts. At this point your hosts files should not have any other than the local host in them. We'll do DNS after spring break:
 
 ```
-
-```
 $ cat /etc/hostname
 router
 ```
 
 The hostname is set to router.
-
-```
 
 ```
 $ cat /etc/hosts
@@ -129,7 +125,6 @@ Your router must have a connection to the internet. It may or may not have names
 
 ```
 $ ping -c 3 localhost
-```
 
 PING localhost (127.0.0.1) 56(84) bytes of data.
 64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.044 ms
@@ -141,8 +136,6 @@ rtt min/avg/max/mdev = 0.044/0.075/0.136/0.043 ms
 ```
 
 If you can't ping localhost you have a problem with your firewall. Review your firewall rules and make sure they match the ones in[IPTables Howto](ipchains_howto.html). Now check to see if you can ping your router's router. First, find the configured router:
-
-```
 
 ```
 $ ip route
@@ -207,8 +200,6 @@ rtt min/avg/max/mdev = 4.349/4.382/4.411/0.080 ms
 ```
 
 Now with IPv6:
-
-```
 
 ```
 $ ping6 -c 3 2001:4860:4860::8888

--- a/source/cis-192/slaac.md
+++ b/source/cis-192/slaac.md
@@ -179,7 +179,7 @@ net.ipv6.conf.ens160.accept_ra = 2
 Once you have all of the configuration in place restart the radvd program:
 
 ```
-router$ sudosystemctl status radvd
+router$ sudo systemctl status radvd
 ```
 
 Check to make sure that your router is sending RAs out:


### PR DESCRIPTION
a lot of the code blocks had an extra set of ``` at the beginning screwing up the code block formatting
I removed them and reformatted some of the code so it makes more sense 